### PR TITLE
fix incompatibilities with MS Edge

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "scripts": {

--- a/persistent-state.js
+++ b/persistent-state.js
@@ -179,7 +179,8 @@ class PersistentState extends HTMLElement {
     } else if ('checkbox' === elem.type) {
       elem.checked = (this.storage.get(key, this.type, this._storageId, false) === 'true');
     } else {
-      elem.value = elem.value || this.storage.get(key, this.type, this._storageId, "");
+      // override text value iff there is not a value given 
+      elem.value = elem.value || this.storage.get(key, this.type, this._storageId, '') || '';
     }
   }
   
@@ -196,4 +197,9 @@ class PersistentState extends HTMLElement {
   }
 }
 
-customElements.define('persistent-state', PersistentState);
+
+if ('customElements' in window) {
+  customElements.define('persistent-state', PersistentState);
+} else {
+  document.registerElement('persistent-state', {prototype: Object.create(PersistentState.prototype)});
+}


### PR DESCRIPTION
- In MS Edge, the `storage.get()` function does not accept the default parameter and returns `null`
- Old version of Edge do not support `customElements.define()`