### PR TITLE
[VALUE] update value when none is specified

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "scripts": {

--- a/persistent-state.js
+++ b/persistent-state.js
@@ -179,7 +179,7 @@ class PersistentState extends HTMLElement {
     } else if ('checkbox' === elem.type) {
       elem.checked = (this.storage.get(key, this.type, this._storageId, false) === 'true');
     } else {
-      elem.value = this.storage.get(key, this.type, this._storageId, '') || '';
+      elem.value = (this.storage.get(key, this.type, this._storageId, '') || '') || elem.value;
     }
   }
   


### PR DESCRIPTION
#10 and #11 showed a disagreement when text element values should be updated. This PR is a middle ground of both. 

- text fields will have their value overwritten by the cache when they exist in the cache
- if no value is found in the cache, then the text field will keep whatever value is in it