### PR TITLE
[WC] add support for custom web components with complex needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,25 @@ If you have a custom element you wish to add support to, you can register it
 manually with the following:
 
 ```js
-new PersistentStateRegistry().supportedTags.push('my-custom-input-element');
+new PersistentStateRegistry().registerCustomElement({
+  // the tag name of your custom web component
+  name: 'my-custom-input-element',
+  
+  // this is the property that <persistent-state> will initialize on your component with any stored values
+  updateProperty: 'customValue',
+
+  // this is the name of the event your component fires when it's internal input value changes
+  changeEvent: 'my-custom-input-element::input-event-name',
+
+  // This is a callback for the PersistentStateRegistry to manage changes from your element.
+  // The return value from this callback will be what is stored/loaded from memory
+  onChange: (customEvent) => {
+    return customEvent.detail.customValue
+  }
+});
 ```
 
-In this example, `<persistent-state>` will only work if `<my-custom-input-element>`
-has a `value` attribute and fires an `input` event when the value changes.
+In this example, `<persistent-state>` will initialize `<my-custom-input-element>`'s `customValue` property with data from the storage when it loads, and store the value returned from the `onChange` callback when the `my-custom-input-element::input-event-name` event fires on the element. 
 
 <details>
 <summary><strong>Here is an exhaustive list of all the support <code>input</code> types</strong></summary>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "authors": [

--- a/demo/custom-webcomponent.js
+++ b/demo/custom-webcomponent.js
@@ -1,0 +1,28 @@
+(() => {
+  const name = 'this-is-a-custom-wc'
+
+  class CustomInputComponent extends HTMLElement {
+    connectedCallback () {
+      this.attachShadow({mode: 'open'}); // this will hide the input from <persistent-state>
+      this.shadowRoot.innerHTML = `
+        <h6>This is a custom Web Component with custom events to make it hard to use with persistent state</h6>
+      `
+      this.textInput = document.createElement('input');
+      this.shadowRoot.appendChild(this.textInput);
+
+      this.textInput.addEventListener('input', (e) => {
+        this.dispatchEvent(new CustomEvent(`${name}::input`, { 
+          bubbles: true, 
+          composed: true, 
+          detail: { internalInputValue: e.currentTarget.value }
+        }))
+      })
+    }
+  }
+  
+  if ('customElements' in window) {
+    customElements.define(name, CustomInputComponent);
+  } else {
+    document.registerElement(name, {prototype: Object.create(CustomInputComponent.prototype)});
+  }
+})()

--- a/demo/custom-webcomponent.js
+++ b/demo/custom-webcomponent.js
@@ -2,6 +2,11 @@
   const name = 'this-is-a-custom-wc'
 
   class CustomInputComponent extends HTMLElement {
+    // when this is updated by persistent-state, this web component will update it's internals 
+    set customValue (value) { 
+      this.textInput.value = value || '';
+    }
+
     connectedCallback () {
       this.attachShadow({mode: 'open'}); // this will hide the input from <persistent-state>
       this.shadowRoot.innerHTML = `

--- a/demo/index.html
+++ b/demo/index.html
@@ -115,6 +115,15 @@
 
     <script>
       window.hiddenInputElem = document.getElementById('hidden-input');
+
+      new PersistentStateRegistry().registerCustomElement({
+        name: 'this-is-a-custom-wc',
+        updateProperty: 'customValue',
+        changeEvent: 'this-is-a-custom-wc::input',
+        onChange: (customEvent) => {
+          return customEvent.detail.internalInputValue
+        }
+      });
     </script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="import" href="../persistent-state.html">
+    <script src="./custom-webcomponent.js"></script>
   </head>
 
   <body>
@@ -88,6 +89,16 @@
         <input type="hidden" id="hidden-input">
       </persistent-state>
     </section>
+    
+    <section>
+      <hr>
+      <h3><code>Custom WebComponents</code></h3>
+      <persistent-state id="custom-wc">
+        <this-is-a-custom-wc></this-is-a-custom-wc>
+      </persistent-state>
+    </section>
+
+
     <section>
       <hr>
       <h3>Not Supported</h3>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "scripts": {

--- a/test/persistent-state_test.html
+++ b/test/persistent-state_test.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>persistent-state test</title>
+  <script src="../demo/custom-webcomponent.js"></script>
   <script src="../persistent-state.js"></script>
 </head>
 <body>
@@ -32,6 +33,10 @@
         <option value="Taco">Taco</option>
         <option value="Fried Rice">Fried Rice</option>
       </select>
+    </persistent-state>
+    
+    <persistent-state id="test-custom-wc">
+      <this-is-a-custom-wc></this-is-a-custom-wc>
     </persistent-state>
   </div>
 </body>


### PR DESCRIPTION
This is the new interface for adding support for custom web components. The old way will still work, but I removed it from the docs. 
```js
new PersistentStateRegistry().registerCustomElement({
  // the tag name of your custom web component
  name: 'my-custom-input-element',
  
  // this is the property that <persistent-state> will initialize on your component with any stored values
  updateProperty: 'customValue',

  // this is the name of the event your component fires when it's internal input value changes
  changeEvent: 'my-custom-input-element::input-event-name',

  // This is a callback for the PersistentStateRegistry to manage changes from your element.
  // The return value from this callback will be what is stored/loaded from memory
  onChange: (customEvent) => {
    return customEvent.detail.customValue
  }
});
```