### PR TITLE
[TEST] add tests to support specific elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ new PersistentStateRegistry().registerCustomElement({
 });
 ```
 
-In this example, `<persistent-state>` will initialize `<my-custom-input-element>`'s `customValue` property with data from the storage when it loads, and store the value returned from the `onChange` callback when the `my-custom-input-element::input-event-name` event fires on the element. 
+In this example, `<persistent-state>` will initialize `<my-custom-input-element>`'s `customValue` property with data from the storage when it loads, and store the value returned from the `onChange` callback when the `my-custom-input-element::input-event-name` event fires on the element. _Note that this is only necessary if the custom element has a Shadow DOM._
 
 <details>
 <summary><strong>Here is an exhaustive list of all the support <code>input</code> types</strong></summary>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "scripts": {

--- a/persistent-state.test.js
+++ b/persistent-state.test.js
@@ -44,6 +44,8 @@ afterAll(async (done) => {
 // RUN TESTS
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/************************************ Test storage functionality ************************************/
+
 test(`The WC loads on the page`, () => {
   return loadTestPage.then(async ({ page }) => {
     const { element, PersistentStateRegistry } = await page.evaluate(() => ({
@@ -159,26 +161,217 @@ test(`data is loaded from sessionStorage by the WC when initialized`, () => {
   })
 });
 
-// @kyle-west reviewed over my shoulder and said he will revisit this later.
-xtest(`select tags are supported`, () => {
+/************************************ Test support for elements ************************************/
+
+test(`<select> elements are supported`, () => {
   return getNewPage().then(async ({ browser, page }) => {
-    let { beforeInit, allPersistentStates } = await page.evaluate(() => ({
-      beforeInit: document.querySelector('persistent-state#test-select select'),
-      allPersistentStates: document.querySelectorAll('persistent-state')
-    }))
+    const selectElement = 'persistent-state#test-element-support select';
 
-    console.log('ALL', allPersistentStates[4]._elements);
-    expect(beforeInit.value).toBe("Banana");
+    await page.waitFor(selectElement);
+    let selectedBefore = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support select').value
+    })
+    expect(selectedBefore).toBe('Banana')
 
-    await page.evaluate(() => {
-      document.querySelector('persistent-state#test-select select#select-foods [value="Bacon"]').selected = true;
-    });
-
-    const refreshedPage = await browser.newPage();
-    await refreshedPage.goto(`http://localhost:${port}/test/persistent-state_test.html`, {waitUntil : ['load', 'domcontentloaded']});
-    let { afterInit } = await refreshedPage.evaluate(() => ({
-      afterInit: document.querySelector('persistent-state#test-select select#select-foods')
-    }))
-    expect(afterInit.value).toBe("Bacon");
+    await page.waitFor(selectElement);
+    await page.select(selectElement, 'Taco')
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(selectElement);
+    let selectedAfter = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support select').value
+    })
+    expect(selectedAfter).toBe('Taco')
   })
 });
+
+test(`<textarea> elements are supported`, () => {
+  return getNewPage().then(async ({ browser, page }) => {
+    const textareaElement = 'persistent-state#test-element-support textarea';
+
+    await page.waitFor(textareaElement);
+    let textareaBefore = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support textarea').value
+    })
+    expect(textareaBefore).toBe('')
+
+    await page.waitFor(textareaElement);
+    await page.type(textareaElement, 'This was entered in by a test')
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(textareaElement);
+    let textareaAfter = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support textarea').value
+    })
+    expect(textareaAfter).toBe('This was entered in by a test')
+  })
+});
+
+test(`<textarea> elements are supported`, () => {
+  return getNewPage().then(async ({ browser, page }) => {
+    const textareaElement = 'persistent-state#test-element-support textarea';
+
+    await page.waitFor(textareaElement);
+    let textareaBefore = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support textarea').value
+    })
+    expect(textareaBefore).toBe('')
+
+    await page.waitFor(textareaElement);
+    await page.type(textareaElement, 'This was entered in by a test')
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(textareaElement);
+    let textareaAfter = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support textarea').value
+    })
+    expect(textareaAfter).toBe('This was entered in by a test')
+  })
+});
+
+// This also covers test for "type" in [color, date, datetime-local, email, month, number, password, range, search, tel, time, url, week]
+// because they share the same API as type="text"
+test(`<input type="text"> element is supported.`, () => {
+  return getNewPage().then(async ({ browser, page }) => {
+    const inputElement = 'persistent-state#test-element-support input[type="text"]';
+
+    await page.waitFor(inputElement);
+    let inputBefore = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support input[type="text"]').value
+    })
+    expect(inputBefore).toBe('')
+
+    await page.waitFor(inputElement);
+    await page.type(inputElement, 'This was entered in by a test')
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(inputElement);
+    let inputAfter = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support input[type="text"]').value
+    })
+    expect(inputAfter).toBe('This was entered in by a test')
+  })
+});
+
+test(`<input type="checkbox"> element is supported`, () => {
+  return getNewPage().then(async ({ browser, page }) => {
+    const inputElement = 'persistent-state#test-element-support input[type="checkbox"]';
+
+    await page.waitFor(inputElement);
+    let inputBefore = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support input[type="checkbox"]').checked
+    })
+    expect(inputBefore).toBe(false)
+
+    await page.waitFor(inputElement);
+    await page.click(inputElement)
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(inputElement);
+    let inputAfter = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support input[type="checkbox"]').checked
+    })
+    expect(inputAfter).toBe(true)
+  })
+});
+
+test(`<input type="radio"> element is supported`, () => {
+  return getNewPage().then(async ({ browser, page }) => {
+    const inputElement = 'persistent-state#test-element-support input[type="radio"]';
+
+    await page.waitFor(inputElement);
+    let inputBefore = await page.evaluate(() => {
+      new FormData(document.querySelector('persistent-state#test-element-support #radio-btns')).get('radio-btn-text')
+    })
+    expect(inputBefore).toBeFalsy()
+
+    await page.waitFor(inputElement);
+    await page.click('persistent-state#test-element-support #o2')
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(inputElement);
+    let inputAfter = await page.evaluate(() => {
+      return new FormData(document.querySelector('persistent-state#test-element-support #radio-btns')).get('radio-btn-text')
+    })
+    expect(inputAfter).toBe('middle item')
+  })
+});
+
+test(`<input type="hidden"> element is supported`, () => {
+  return getNewPage().then(async ({ browser, page }) => {
+    const inputElement = 'persistent-state#test-element-support input[type="hidden"]';
+
+    await page.waitFor(inputElement);
+    let inputBefore = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support input[type="hidden"]').value
+    })
+    expect(inputBefore).toBe('')
+
+    await page.evaluate(() => {
+      document.querySelector('persistent-state#test-element-support input[type="hidden"]').value = 'This was entered in by a test'
+    })
+    
+    // reload the page
+    const navigationPromise = page.waitForNavigation()
+    await page.evaluate(() => window.location.reload())
+    await navigationPromise
+    
+    await page.waitFor(inputElement);
+    let inputAfter = await page.evaluate(() => {
+      return document.querySelector('persistent-state#test-element-support input[type="hidden"]').value
+    })
+    expect(inputAfter).toBe('This was entered in by a test')
+  })
+});
+
+// Having issues with puppeteer and shadowRoot to test this
+// test(`custom web components are supported`, () => {
+//   return getNewPage().then(async ({ browser, page }) => {
+//     const inputElement = 'persistent-state#test-custom-wc-support';
+
+//     await page.waitFor(inputElement);
+//     let inputBefore = await page.evaluate(() => {
+//       return document.querySelector("#test-custom-wc-support this-is-a-custom-wc").shadowRoot
+//     })
+//     expect(inputBefore).toBe('meh')
+
+//     // await page.evaluate(() => {
+//     //   document.querySelector("#test-custom-wc-support this-is-a-custom-wc").shadowRoot.querySelector("input") = 'This was entered in by a test'
+//     // })
+    
+//     // reload the page
+//     // const navigationPromise = page.waitForNavigation()
+//     // await page.evaluate(() => window.location.reload())
+//     // await navigationPromise
+    
+//     // await page.waitFor(inputElement);
+//     // let inputAfter = await page.evaluate(() => {
+//     //   return document.querySelector("#test-custom-wc-support this-is-a-custom-wc").shadowRoot.querySelector("input").value
+//     // })
+//     // expect(inputAfter).toBe('This was entered in by a test')
+//   })
+// });

--- a/test/persistent-state_test.html
+++ b/test/persistent-state_test.html
@@ -5,10 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>persistent-state test</title>
-  <script src="../demo/custom-webcomponent.js"></script>
   <script src="../persistent-state.js"></script>
+  <script src="../demo/custom-webcomponent.js"></script>
 </head>
 <body>
+  <script>
+    new PersistentStateRegistry().registerCustomElement({
+      name: 'this-is-a-custom-wc',
+      updateProperty: 'customValue',
+      changeEvent: 'this-is-a-custom-wc::input',
+      onChange: (customEvent) => {
+        return customEvent.detail.internalInputValue
+      }
+    });
+  </script>
   <div id="root">
     <persistent-state id="test-1">
       <input type="text" />
@@ -26,16 +36,45 @@
       <input type="text" id="the-input-tag-id"/>
     </persistent-state>
 
-    <persistent-state id="test-select">
-      <select id="select-foods">
+    <hr />
+
+    <persistent-state id="test-element-support">
+      <textarea></textarea>
+
+      <select>
         <option value="Banana">Banana</option>
         <option value="Bacon">Bacon</option>
         <option value="Taco">Taco</option>
         <option value="Fried Rice">Fried Rice</option>
       </select>
+
+      <input type="checkbox">
+
+      <form id="radio-btns">
+        <input type="radio" name="radio-btn-text" id="o1" value="first item"><label for="o1">first item</label>
+        <input type="radio" name="radio-btn-text" id="o2" value="middle item"><label for="o2">middle item</label>
+        <input type="radio" name="radio-btn-text" id="o3" value="last item"><label for="o3">last item</label>
+      </form>
+
+      <input type="color">
+      <input type="date">
+      <input type="datetime-local">
+      <input type="email">
+      <input type="month">
+      <input type="number">
+      <input type="password">
+      <input type="range">
+      <input type="search">
+      <input type="tel">
+      <input type="text">
+      <input type="time">
+      <input type="url">
+      <input type="week">
+
+      <input type="hidden" id="hidden-input">
     </persistent-state>
     
-    <persistent-state id="test-custom-wc">
+    <persistent-state id="test-custom-wc-support">
       <this-is-a-custom-wc></this-is-a-custom-wc>
     </persistent-state>
   </div>


### PR DESCRIPTION
The original tests were sufficient to validate the storage mechanism, and the `<persistent-state>` API. These new tests validate support for each input type, including `<select>` and `<textarea>` tags. The important thing to note is that the `<input>` tests validate the individual types that we support. `type="text"` represents those input types that have a standard API, along with color, date, datetime-local, email, month, number, password, range, search, tel, time, url, and week.

Additionally, we now validate the improved web component support in #18. 