### PR TITLE
Support storing objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ new PersistentStateRegistry().registerCustomElement({
   // this is the name of the event your component fires when it's internal input value changes
   changeEvent: 'my-custom-input-element::input-event-name',
 
+  // [OPTIONAL] specify if the stored data should be handled as JSON (default: false)
+  isJSON: true,
+
   // This is a callback for the PersistentStateRegistry to manage changes from your element.
   // The return value from this callback will be what is stored/loaded from memory
   onChange: (customEvent) => {

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ new PersistentStateRegistry().registerCustomElement({
   // this is the property that <persistent-state> will initialize on your component with any stored values
   updateProperty: 'customValue',
 
-  // this is the name of the event your component fires when it's internal input value changes
-  changeEvent: 'my-custom-input-element::input-event-name',
-
   // [OPTIONAL] specify if the stored data should be handled as JSON (default: false)
   isJSON: true,
+
+  // this is the name of the event your component fires when it's internal input value changes
+  changeEvent: 'my-custom-input-element::input-event-name',
 
   // This is a callback for the PersistentStateRegistry to manage changes from your element.
   // The return value from this callback will be what is stored/loaded from memory

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "authors": [

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,6 +2,7 @@
   <head>
     <link rel="import" href="../persistent-state.html">
     <script src="./custom-webcomponent.js"></script>
+    <script src="./json-wc.js"></script>
   </head>
 
   <body>
@@ -96,6 +97,9 @@
       <persistent-state id="custom-wc">
         <this-is-a-custom-wc></this-is-a-custom-wc>
       </persistent-state>
+      <persistent-state id="custom-wc-json">
+        <json-wc></json-wc>
+      </persistent-state>
     </section>
 
 
@@ -122,6 +126,17 @@
         changeEvent: 'this-is-a-custom-wc::input',
         onChange: (customEvent) => {
           return customEvent.detail.internalInputValue
+        }
+      });
+
+      new PersistentStateRegistry().registerCustomElement({
+        name: 'json-wc',
+        updateProperty: 'state',
+        isJSON: true,
+        changeEvent: 'json-wc::click',
+        onChange: (customEvent) => {
+          let { state } = customEvent.detail
+          return Object.assign({}, state, {loadedFromMemory: true})
         }
       });
     </script>

--- a/demo/json-wc.js
+++ b/demo/json-wc.js
@@ -1,0 +1,53 @@
+(() => {
+  const name = 'json-wc'
+
+  class JSONWebComponent extends HTMLElement {
+    constructor (...args) {
+      super(...args);
+
+      if (!this._state) {
+        this._state = {
+          clickCount: 0,
+          loadedFromMemory: false
+        }
+      }
+    }
+
+    set state (value) {
+      if (!value) return;
+      this._state = value;
+      if (this.code) this.code.innerHTML = JSON.stringify(this._state);
+    }
+
+    connectedCallback () {
+      this.attachShadow({mode: 'open'}); // this will hide the button from <persistent-state>
+      this.shadowRoot.innerHTML = `
+        <h6>This is a custom Web Component, which stores data as a json object:</h6>
+      `
+      this.button = document.createElement('button');
+      this.button.innerHTML = 'Click Me To increment internal counter!'
+
+      this.code = document.createElement('code');
+      this.code.innerHTML = JSON.stringify(this._state);
+
+      this.shadowRoot.appendChild(this.button);
+      this.shadowRoot.appendChild(this.code);
+
+      this.button.addEventListener('click', (e) => {
+        this._state.clickCount++;
+        this.code.innerHTML = JSON.stringify(this._state);
+        this.dispatchEvent(new CustomEvent(`${name}::click`, { 
+          bubbles: true, 
+          composed: true, 
+          detail: { state: this._state }
+        }))
+      })
+    }
+  }
+  
+  if ('customElements' in window) {
+    customElements.define(name, JSONWebComponent);
+  } else {
+    document.registerElement(name, {prototype: Object.create(JSONWebComponent.prototype)});
+  }
+})()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistent-state",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "A native web component that holds onto the state of input elements during a session and/or between sessions.",
   "main": "persistent-state.js",
   "scripts": {

--- a/test/persistent-state_test.html
+++ b/test/persistent-state_test.html
@@ -7,6 +7,7 @@
   <title>persistent-state test</title>
   <script src="../persistent-state.js"></script>
   <script src="../demo/custom-webcomponent.js"></script>
+  <script src="../demo/json-wc.js"></script>
 </head>
 <body>
   <script>
@@ -16,6 +17,17 @@
       changeEvent: 'this-is-a-custom-wc::input',
       onChange: (customEvent) => {
         return customEvent.detail.internalInputValue
+      }
+    });
+
+    new PersistentStateRegistry().registerCustomElement({
+      name: 'json-wc',
+      updateProperty: 'state',
+      isJSON: true,
+      changeEvent: 'json-wc::click',
+      onChange: (customEvent) => {
+        let { state } = customEvent.detail
+        return Object.assign({}, state, {loadedFromMemory: true})
       }
     });
   </script>
@@ -76,6 +88,9 @@
     
     <persistent-state id="test-custom-wc-support">
       <this-is-a-custom-wc></this-is-a-custom-wc>
+    </persistent-state>
+    <persistent-state id="test-wc-json-support">
+      <json-wc></json-wc>
     </persistent-state>
   </div>
 </body>


### PR DESCRIPTION
I tested that the regular input fields still persist state, and the custom fields are capable of storing objects.

We added the following interface to consume this feature: 
![Screen Shot 2019-08-14 at 12 34 41 PM](https://user-images.githubusercontent.com/18150457/63046548-edc19b80-be8f-11e9-8bb9-cc47273d71a0.png)